### PR TITLE
Added nested routes to the nextjs tutorial

### DIFF
--- a/my-nextjs-app/.eslintrc.json
+++ b/my-nextjs-app/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/my-nextjs-app/app/blog/first-post/page.tsx
+++ b/my-nextjs-app/app/blog/first-post/page.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+import React from 'react'
+
+
+
+const FirstPost = () => {
+  return (
+    <div className='p-24'>
+      <h1 className='text-3xl text-font-bold mb-4'>This is my first blog post</h1>
+      <p className='mb-4'>This is my first blog post</p>
+      <Link className='text-blue-600 hover:underline-offset-1' href={"/blog"}>Back to Blog</Link>
+    </div>
+  )
+}
+
+export default FirstPost

--- a/my-nextjs-app/app/blog/page.tsx
+++ b/my-nextjs-app/app/blog/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+
+export default function Blog() {
+  return (
+    <div className="p-24">
+      <h1 className="text-3xl font-bold mb-4">Our Blog</h1>
+      <ul className="space-y-4">
+        <li>
+          <Link href="/blog/first-post" className="text-blue-500 hover:underline">
+            First Blog Post
+          </Link>
+        </li>
+        <li>
+          <Link href="/blog/second-post" className="text-blue-500 hover:underline">
+            Second Blog Post
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/my-nextjs-app/app/blog/second-post/page.tsx
+++ b/my-nextjs-app/app/blog/second-post/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import React from 'react'
+
+
+const SecondPost = () => {
+  return (
+    <div className='p-24 mb-4'>
+      <h1 className='text-3xl font-bold'>Second Blog Post</h1>
+      <p>This is my second blog post</p>
+      <Link href="/blog" className='text-blue-500 hover:underline'>Back to blog</Link>
+    </div>
+  )
+}
+
+export default SecondPost

--- a/my-nextjs-app/package.json
+++ b/my-nextjs-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
This pull request introduces multiple changes to the Next.js application:

### TL;DR

Added new blog pages and integrated prettier configuration.

### What changed?

1. Updated `.eslintrc.json` to extend prettier configuration along with `next/core-web-vitals`.
2. Created three new pages under `app/blog` directory:
  - `app/blog/page.tsx`: Lists all blog posts with links to individual posts.
  - `app/blog/first-post/page.tsx`: Displays the first blog post.
  - `app/blog/second-post/page.tsx`: Displays the second blog post.
3. Modified `package.json` to use `--turbo` flag for `next dev` script.

### How to test?

1. Run `npm install` to ensure all dependencies are updated.
2. Start the development server using `npm run dev`.
3. Navigate to `/blog` to view the list of blog posts.
4. Click on each blog post link to ensure the pages render correctly.

### Why make this change?

To enhance the blogging functionality and code formatting standards of the application.

---

I added the first-post and second-post directories and inside of them
added page.tsx to learn how nested routes work. I also used the link
thing to link different locations in the webpage together`